### PR TITLE
Support sending tags to sentry

### DIFF
--- a/src/Serilog.Sinks.Sentry/SentrySink.cs
+++ b/src/Serilog.Sinks.Sentry/SentrySink.cs
@@ -6,6 +6,7 @@ using Serilog.Events;
 
 using SharpRaven;
 using SharpRaven.Data;
+using System.Collections.Generic;
 
 namespace Serilog.Sinks.Sentry
 {
@@ -16,7 +17,7 @@ namespace Serilog.Sinks.Sentry
         private readonly string _environment;
         private readonly IFormatProvider _formatProvider;
         private readonly string _release;
-        private readonly string[] _tags = new string[0];
+        private readonly IEnumerable<string> _tags = new string[0];
 
         /// <summary>
         ///     Initializes a new instance of the <see cref="SentrySink" /> class.
@@ -34,7 +35,7 @@ namespace Serilog.Sinks.Sentry
             _environment = environment;
             if (!string.IsNullOrWhiteSpace(tags))
             {
-                _tags = tags.Split(',');
+                _tags = tags.Split(new[] { ',' }, StringSplitOptions.RemoveEmptyEntries).Select(t => t.Trim());
             }
         }
 

--- a/src/Serilog.Sinks.Sentry/SentrySinkExtensions.cs
+++ b/src/Serilog.Sinks.Sentry/SentrySinkExtensions.cs
@@ -18,6 +18,7 @@ namespace Serilog.Sinks.Sentry
         /// <param name="environment">The environment.</param>
         /// <param name="restrictedToMinimumLevel">The restricted to minimum level.</param>
         /// <param name="formatProvider">The format provider.</param>
+        /// <param name="tags">Comma separated list of properties to treat as tags in sentry.</param>
         /// <returns>The logger configuration.</returns>
         /// <exception cref="ArgumentException">Value cannot be null or whitespace. - dsn</exception>
         public static LoggerConfiguration Sentry(
@@ -26,7 +27,8 @@ namespace Serilog.Sinks.Sentry
             string release = null,
             string environment = null,
             LogEventLevel restrictedToMinimumLevel = LogEventLevel.Error,
-            IFormatProvider formatProvider = null)
+            IFormatProvider formatProvider = null,
+            string tags = null)
         {
             if (string.IsNullOrWhiteSpace(dsn))
             {
@@ -34,7 +36,7 @@ namespace Serilog.Sinks.Sentry
             }
 
             return loggerConfiguration.Sink(
-                new SentrySink(formatProvider, dsn, release, environment),
+                new SentrySink(formatProvider, dsn, release, environment, tags),
                 restrictedToMinimumLevel);
         }
     }

--- a/src/Serilog.Sinks.Sentry/Serilog.Sinks.Sentry.csproj
+++ b/src/Serilog.Sinks.Sentry/Serilog.Sinks.Sentry.csproj
@@ -29,6 +29,7 @@
 
   <ItemGroup>
     <Reference Include="Microsoft.CSharp" />
+    <Reference Include="System.Core" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
Serilog only knows about additional properties to log, f.e. in LogContext. Sentry differentiates between 'Extra'-properties and 'tags'. Both are just key/value pairs of strings but they get treated different in Sentry. Tags get indexed and the log data is easy filterable by tags, f.e. 
For that reasons I implemented the ability to specify property keys in a comma-separated optional string parameter to specify serilog properties that goes to Sentry Tags instead of Additional Data.
I think this is of general use and I would be glad if you could include that feature in your package so others could also use it and I don't have to maintain a fork of the sink anymore.