### PR TITLE
feature: Header, cookie, data, etc. scrubbing

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,21 @@ var log = new LoggerConfiguration()
 log.Error("This error goes to Sentry.");
 ```
 
+### Data scrubbing
+
+Some of the logged content might contain sensitive data and should therefore not be sent to Sentry. When setting up the Sentry Sink it is possible to provide a custom `IScrubber` implementation which will be passed the serialized data that is about to be sent to Sentry for scrubbing / cleaning.
+
+Adding a scrubber would look like this:
+
+```csharp
+var log = new LoggerConfiguration()
+    .WriteTo.Sentry("Sentry DSN", dataScrubber: new MyDataScrubber())
+    .Enrich.FromLogContext()
+    .CreateLogger();
+```
+
+`MyDataScrubber` has to implement the interface `SharpRaven.Logging.IScrubber`. Check the [Web Demo Startup.cs for further details](demos/SentryWeb/Startup.cs) and the [example implementation of a scrubber](demos/SentryWeb/Scrubbing/CustomLogScrubber.cs) .
+
 ### Capturing HttpContext (ASP.NET Core)
 
 In order to capture a user, request body and headers, some additional steps are required.

--- a/demos/SentryWeb/Scrubbing/CustomLogScrubber.cs
+++ b/demos/SentryWeb/Scrubbing/CustomLogScrubber.cs
@@ -1,0 +1,32 @@
+using System.Collections.Generic;
+using System.Linq;
+using SharpRaven.Logging;
+using SharpRaven.Logging.Filters;
+using SharpRaven.Utilities;
+
+namespace SentryWeb.Scrubbing
+{
+    public class CustomLogScrubber : IScrubber
+    {
+        private readonly List<IFilter> _filters;
+
+        public CustomLogScrubber()
+        {
+            _filters = new List<IFilter>
+            {
+                new CreditCardFilter(), // from RavenClient it self
+                new DivisionByZeroFilter() // our example scrubber
+            };
+        }
+
+        public string Scrub(string input)
+        {
+            if (SystemUtil.IsNullOrWhiteSpace(input))
+            {
+                return input;
+            }
+
+            return _filters.Aggregate(input, (current, f) => f.Filter(current));
+        }
+    }
+}

--- a/demos/SentryWeb/Scrubbing/DivisionByZeroFilter.cs
+++ b/demos/SentryWeb/Scrubbing/DivisionByZeroFilter.cs
@@ -1,0 +1,19 @@
+using System.Text.RegularExpressions;
+using SharpRaven.Logging;
+
+namespace SentryWeb.Scrubbing
+{
+    /// <summary>
+    /// Silly example of replacing zero with hero when the divide by zero exception is thrown.
+    /// </summary>
+    public class DivisionByZeroFilter : IFilter
+    {
+        private static readonly Regex phoneRegex =
+            new Regex("zero", RegexOptions.Compiled);
+
+        public string Filter(string input)
+        {
+            return phoneRegex.Replace(input, "##-HERO-##");
+        }
+    }
+}

--- a/demos/SentryWeb/Startup.cs
+++ b/demos/SentryWeb/Startup.cs
@@ -6,9 +6,9 @@ using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
+using SentryWeb.Scrubbing;
 using Serilog;
-using Serilog.Sinks.Sentry;
-using Serilog.Sinks.Sentry.AspNetCore;
+using SharpRaven.Data;
 
 namespace SentryWeb
 {
@@ -17,11 +17,14 @@ namespace SentryWeb
         public Startup(IConfiguration configuration)
         {
             Configuration = configuration;
-            
+
             Log.Logger = new LoggerConfiguration()
                 .WriteTo.Console()
                 // Insert Sentry DSN here
-                .WriteTo.Sentry("")
+                .WriteTo.Sentry(
+                    "", 
+                    dataScrubber: new CustomLogScrubber()
+                )
                 .Enrich.FromLogContext()
                 // Add Http Context for Sentry
                 .Destructure.With<HttpContextDestructingPolicy>()

--- a/src/Serilog.Sinks.Sentry/SentrySinkExtensions.cs
+++ b/src/Serilog.Sinks.Sentry/SentrySinkExtensions.cs
@@ -4,6 +4,7 @@ using Serilog.Configuration;
 using Serilog.Events;
 
 using SharpRaven.Data;
+using SharpRaven.Logging;
 
 namespace Serilog
 {
@@ -25,6 +26,7 @@ namespace Serilog
         /// <param name="jsonPacketFactory">The json packet factory.</param>
         /// <param name="sentryUserFactory">The sentry user factory.</param>
         /// <param name="sentryRequestFactory">The sentry request factory.</param>
+        /// <param name="dataScrubber">An <see cref="IScrubber"/> implementation for cleaning up logs before sending to Sentry</param>
         /// <returns>
         /// The logger configuration.
         /// </returns>
@@ -39,7 +41,9 @@ namespace Serilog
             string tags = null,
             IJsonPacketFactory jsonPacketFactory = null,
             ISentryUserFactory sentryUserFactory = null,
-            ISentryRequestFactory sentryRequestFactory = null)
+            ISentryRequestFactory sentryRequestFactory = null,
+            IScrubber dataScrubber = null
+            )
         {
             return loggerConfiguration.Sink(
                 new SentrySink(
@@ -50,7 +54,8 @@ namespace Serilog
                     tags,
                     jsonPacketFactory,
                     sentryUserFactory,
-                    sentryRequestFactory),
+                    sentryRequestFactory,
+                    dataScrubber),
                 restrictedToMinimumLevel);
         }
     }


### PR DESCRIPTION
This PR adds support for scrubbing data before it being sent to Sentry.

It hooks into the `RavenSharp` data scrubber by allowing the developer to pass an `IScrubber` when configuring the Sentry log sink.

Closes #16 