### PR TITLE
Set configured sentry logger in all cases.

### DIFF
--- a/src/Serilog.Sinks.Sentry.AspNetCore/Serilog.Sinks.Sentry.AspNetCore.csproj
+++ b/src/Serilog.Sinks.Sentry.AspNetCore/Serilog.Sinks.Sentry.AspNetCore.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <Description>A Sentry sink for Serilog</Description>
-    <VersionPrefix>2.4.0</VersionPrefix>
+    <VersionPrefix>2.5.0</VersionPrefix>
     <Authors>Oleg Shevchenko</Authors>
     <TargetFrameworks>net451;netstandard2.0</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>

--- a/src/Serilog.Sinks.Sentry/SentrySink.cs
+++ b/src/Serilog.Sinks.Sentry/SentrySink.cs
@@ -101,7 +101,6 @@ namespace Serilog
                                   _sentryRequestFactory ?? new SentryRequestFactory(httpContext),
                                   _sentryUserFactory ?? new SentryUserFactory(httpContext))
                 {
-                    Logger = _logger,
                     Release = _release,
                     Environment = _environment
                 };
@@ -115,6 +114,7 @@ namespace Serilog
                         };
             }
 
+            ravenClient.Logger = _logger;
             ravenClient.LogScrubber = _dataScrubber;
             ravenClient.Capture(sentryEvent);
         }

--- a/src/Serilog.Sinks.Sentry/Serilog.Sinks.Sentry.csproj
+++ b/src/Serilog.Sinks.Sentry/Serilog.Sinks.Sentry.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <Description>A Sentry sink for Serilog</Description>
-    <VersionPrefix>2.4.0</VersionPrefix>
+    <VersionPrefix>2.5.0</VersionPrefix>
     <Authors>Oleg Shevchenko</Authors>
     <TargetFrameworks>net45;netstandard2.0</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>


### PR DESCRIPTION
This fixes a bug in my previous PR where the logger is not getting set in both branches of the if/else block in the SentrySink class.