### PR TITLE
Provide SPDX license identifier for packages

### DIFF
--- a/src/Serilog.Sinks.Sentry.AspNetCore/Serilog.Sinks.Sentry.AspNetCore.csproj
+++ b/src/Serilog.Sinks.Sentry.AspNetCore/Serilog.Sinks.Sentry.AspNetCore.csproj
@@ -13,6 +13,7 @@
     <PackageReleaseNotes>https://github.com/olsh/serilog-sinks-sentry/releases</PackageReleaseNotes>
     <PackageProjectUrl>https://github.com/olsh/serilog-sinks-sentry</PackageProjectUrl>
     <PackageLicenseUrl>https://raw.githubusercontent.com/olsh/serilog-sinks-sentry/master/LICENSE</PackageLicenseUrl>
+    <PackageLicenseExpression>MIT</PackageLicenseExpression>
     <PackageIconUrl>http://serilog.net/images/serilog-sink-nuget.png</PackageIconUrl>
     <RepositoryType>git</RepositoryType>
     <RepositoryUrl>https://github.com/olsh/serilog-sinks-sentry</RepositoryUrl>

--- a/src/Serilog.Sinks.Sentry/Serilog.Sinks.Sentry.csproj
+++ b/src/Serilog.Sinks.Sentry/Serilog.Sinks.Sentry.csproj
@@ -13,6 +13,7 @@
     <PackageReleaseNotes>https://github.com/olsh/serilog-sinks-sentry/releases</PackageReleaseNotes>
     <PackageProjectUrl>https://github.com/olsh/serilog-sinks-sentry</PackageProjectUrl>
     <PackageLicenseUrl>https://raw.githubusercontent.com/olsh/serilog-sinks-sentry/master/LICENSE</PackageLicenseUrl>
+    <PackageLicenseExpression>MIT</PackageLicenseExpression>
     <PackageIconUrl>http://serilog.net/images/serilog-sink-nuget.png</PackageIconUrl>
     <RepositoryType>git</RepositoryType>
     <RepositoryUrl>https://github.com/olsh/serilog-sinks-sentry</RepositoryUrl>


### PR DESCRIPTION
This change adds the SPDX license identifier to the generated NuGet packages by adding the appropriate [PackageLicenseExpression](https://docs.microsoft.com/en-us/dotnet/standard/library-guidance/nuget) tag.

**Why?** Companies use the license information provided by package managers to ensure compliance across large projects. Providing an SPDX license identifier makes it simpler for people to work with automated tools like [LicenseFinder](https://github.com/pivotal/LicenseFinder) or GitLab's license scanning feature.