### PR TITLE
Add ability to ignore logs by predicate

### DIFF
--- a/src/Serilog.Sinks.Sentry/SentrySink.cs
+++ b/src/Serilog.Sinks.Sentry/SentrySink.cs
@@ -83,7 +83,7 @@ namespace Serilog
         }
 
         /// <inheritdoc />
-        public virtual void Emit(LogEvent logEvent)
+        public void Emit(LogEvent logEvent)
         {
             if (_logIncludePredicate != null)
             {

--- a/src/Serilog.Sinks.Sentry/SentrySinkExtensions.cs
+++ b/src/Serilog.Sinks.Sentry/SentrySinkExtensions.cs
@@ -18,6 +18,7 @@ namespace Serilog
         /// </summary>
         /// <param name="loggerConfiguration">The logger configuration.</param>
         /// <param name="dsn">The DSN.</param>
+        /// <param name="logIncludeSwitch"></param>
         /// <param name="release">The release.</param>
         /// <param name="environment">The environment.</param>
         /// <param name="restrictedToMinimumLevel">The restricted to minimum level.</param>
@@ -32,8 +33,7 @@ namespace Serilog
         /// The logger configuration.
         /// </returns>
         // ReSharper disable once StyleCop.SA1625
-        public static LoggerConfiguration Sentry(
-            this LoggerSinkConfiguration loggerConfiguration,
+        public static LoggerConfiguration Sentry(this LoggerSinkConfiguration loggerConfiguration,
             string dsn,
             string release = null,
             string environment = null,
@@ -44,7 +44,8 @@ namespace Serilog
             ISentryUserFactory sentryUserFactory = null,
             ISentryRequestFactory sentryRequestFactory = null,
             IScrubber dataScrubber = null,
-            string logger = null)
+            string logger = null,
+            Func<LogEvent, bool> logIncludeSwitch = null)
         {
             return loggerConfiguration.Sink(
                 new SentrySink(
@@ -57,7 +58,8 @@ namespace Serilog
                     sentryUserFactory,
                     sentryRequestFactory,
                     dataScrubber,
-                    logger),
+                    logger,
+                    logIncludeSwitch),
                 restrictedToMinimumLevel);
         }
     }

--- a/src/Serilog.Sinks.Sentry/SentrySinkExtensions.cs
+++ b/src/Serilog.Sinks.Sentry/SentrySinkExtensions.cs
@@ -18,7 +18,7 @@ namespace Serilog
         /// </summary>
         /// <param name="loggerConfiguration">The logger configuration.</param>
         /// <param name="dsn">The DSN.</param>
-        /// <param name="logIncludeSwitch"></param>
+        /// <param name="logIncludeSwitch">Filter log events to include only those that match a predicate.</param>
         /// <param name="release">The release.</param>
         /// <param name="environment">The environment.</param>
         /// <param name="restrictedToMinimumLevel">The restricted to minimum level.</param>


### PR DESCRIPTION
This PR adds more granular control over what should be logged.
use case: i need to log event with any `LogLevel` but only it has `Exception` property.
code: 
```
configuration.WriteTo.Sentry(sentryDsn.AbsoluteUri, 
    restrictedToMinimumLevel: LogEventLevel.Information, 
    logIncludeSwitch: @event => @event.Exception != null);
```